### PR TITLE
Ensure Balancer text resizes on Home screen

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ export default function Home() {
   return (
     <Layout>
       <motion.div
-        className="max-w-xl px-5 xl:px-0"
+        className="w-full max-w-xl px-5 xl:px-0"
         initial="hidden"
         whileInView="show"
         animate="show"


### PR DESCRIPTION
Small fix to ensure the Balancer text resizes after the window width goes from large to small to large again.

As per this Balancer issue: https://github.com/shuding/react-wrap-balancer/issues/45

**Recording of it before:**

https://user-images.githubusercontent.com/30637046/227718710-1c3a91a0-562b-42bb-b8bb-72f9b1febc51.mov


**Recording of it after:**

https://user-images.githubusercontent.com/30637046/227718725-7aea7ffc-db9d-4d37-9d55-25c60d5b9019.mov
