### PR TITLE
🐛 fix(sitemap.ts): add type to user object in map function

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -14,7 +14,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: "https://precedent.dev",
       lastModified: new Date(),
     },
-    ...users.map((user) => ({
+    ...users.map((user: { id: any; }) => ({
       url: `https://precedent.dev/${user.id}`,
       lastModified: new Date(),
     })),


### PR DESCRIPTION
While running `pnpm build` build fails because of the error below.
<img width="673" alt="image" src="https://user-images.githubusercontent.com/7461799/232820052-70a02c0a-bd3b-42af-b5a7-771845c8d733.png">

The map function in the sitemap module was missing a type for the user object. This commit adds the type to the user object to prevent build errors.




