### PR TITLE
Fixed : button width and tooltip disappearing

### DIFF
--- a/components/home/component-grid.tsx
+++ b/components/home/component-grid.tsx
@@ -14,7 +14,7 @@ export default function ComponentGrid() {
       <DemoModal />
       <button
         onClick={() => setShowDemoModal(true)}
-        className="flex w-40 items-center justify-center rounded-md border border-gray-300 px-3 py-2 transition-all duration-75 hover:border-gray-800 focus:outline-none active:bg-gray-100"
+        className="flex w-36 items-center justify-center rounded-md border border-gray-300 px-3 py-2 transition-all duration-75 hover:border-gray-800 focus:outline-none active:bg-gray-100"
       >
         <p className="text-gray-600">Modal</p>
       </button>
@@ -37,18 +37,17 @@ export default function ComponentGrid() {
       >
         <button
           onClick={() => setOpenPopover(!openPopover)}
-          className="flex w-40 items-center justify-between rounded-md border border-gray-300 px-4 py-2 transition-all duration-75 hover:border-gray-800 focus:outline-none active:bg-gray-100"
+          className="flex w-36 items-center justify-between rounded-md border border-gray-300 px-4 py-2 transition-all duration-75 hover:border-gray-800 focus:outline-none active:bg-gray-100"
         >
           <p className="text-gray-600">Popover</p>
           <ChevronDown
-            className={`h-4 w-4 text-gray-600 transition-all ${
-              openPopover ? "rotate-180" : ""
-            }`}
+            className={`h-4 w-4 text-gray-600 transition-all ${openPopover ? "rotate-180" : ""
+              }`}
           />
         </button>
       </Popover>
       <Tooltip content="Precedent is an opinionated collection of components, hooks, and utilities for your Next.js project.">
-        <div className="flex w-40 cursor-default items-center justify-center rounded-md border border-gray-300 px-3 py-2 transition-all duration-75 hover:border-gray-800 focus:outline-none active:bg-gray-100">
+        <div className="flex w-36 cursor-default items-center justify-center rounded-md border border-gray-300 px-3 py-2 transition-all duration-75 hover:border-gray-800 focus:outline-none active:bg-gray-100">
           <p className="text-gray-600">Tooltip</p>
         </div>
       </Tooltip>

--- a/components/shared/tooltip.tsx
+++ b/components/shared/tooltip.tsx
@@ -23,7 +23,7 @@ export default function Tooltip({
       {isMobile && (
         <button
           type="button"
-          className={`${fullWidth ? "w-full" : "inline-flex"} sm:hidden`}
+          className={`${fullWidth ? "w-full" : "inline-flex"}`}
           onClick={() => setOpenTooltip(true)}
         >
           {children}


### PR DESCRIPTION
### Issue
While changing the size of screen the button width are overlapping with the container and tooltip button is hidding in medium screen size.
## Video
[chrome-capture-2023-3-19.webm](https://user-images.githubusercontent.com/56172425/233063677-24395158-84c0-4abd-bd9e-43c323ff03d4.webm)
## Screenshot
<img width="528" alt="Screenshot 2023-04-19 at 4 54 38 PM" src="https://user-images.githubusercontent.com/56172425/233064577-e26416e6-c5d6-41aa-b017-2ffd07978240.png">
<img width="530" alt="Screenshot 2023-04-19 at 4 59 06 PM" src="https://user-images.githubusercontent.com/56172425/233064613-4ba0ace6-e2b2-487b-882d-2c705ca08ae3.png">

### Fixed
Reduced the width by 1 rem ie w-36 and removed the sm:hidden from the tooltip button

## Video
[Fixed version.webm](https://user-images.githubusercontent.com/56172425/233064977-919bbf66-94e5-4fbc-8588-95639e2e97ad.webm)

