### PR TITLE
Sync Popover Open State

### DIFF
--- a/components/shared/popover.tsx
+++ b/components/shared/popover.tsx
@@ -26,7 +26,10 @@ export default function Popover({
         <Leaflet setShow={setOpenPopover}>{content}</Leaflet>
       )}
       {isDesktop && (
-        <PopoverPrimitive.Root>
+        <PopoverPrimitive.Root
+          open={openPopover}
+          onOpenChange={(isOpen) => setOpenPopover(isOpen)}
+        >
           <PopoverPrimitive.Trigger className="inline-flex" asChild>
             {children}
           </PopoverPrimitive.Trigger>


### PR DESCRIPTION
The `openPopover` prop does not match the `open` state of the `PopoverPrimitive`. 

With this change you should be able to manually trigger popup open/close on desktop by simply updating the parent's `openPopover` state.