### PR TITLE
Using user's name value in profile avatar instead of email value

### DIFF
--- a/components/layout/user-dropdown.tsx
+++ b/components/layout/user-dropdown.tsx
@@ -8,7 +8,7 @@ import Image from "next/image";
 import { Session } from "next-auth";
 
 export default function UserDropdown({ session }: { session: Session }) {
-  const { email, image } = session?.user || {};
+  const { name, email, image } = session?.user || {};
   const [openPopover, setOpenPopover] = useState(false);
 
   if (!email) return null;
@@ -51,7 +51,7 @@ export default function UserDropdown({ session }: { session: Session }) {
         >
           <Image
             alt={email}
-            src={image || `https://avatars.dicebear.com/api/micah/${email}.svg`}
+            src={image || `https://avatars.dicebear.com/api/micah/${name}.svg`}
             width={40}
             height={40}
           />


### PR DESCRIPTION
I noticed using user's email address in dicebear.com URL to create a random avatar profile, It's better to not share user's email with third-parties like Dicebear, so I changed 'email' with 'name'.