### PR TITLE
Update schema.prisma for Prisma migration on vercel

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,6 @@ datasource db {
   provider = "postgresql"
   url = env("POSTGRES_PRISMA_URL") // uses connection pooling
   directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-  shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
 }
 
 


### PR DESCRIPTION
Removed 'shadowDatabaseUrl' in prisma schema for migration on vercel. Prisma docs stated that 'shadowDatabaseUrl' shouldn't be the same as 'directUrl'; as it causes errors.

Prisma Docs:
https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database

Potential Problem regarding migration:
https://github.com/prisma/prisma/issues/19234#issuecomment-1624261912