### PR TITLE
Update React hook `useScroll`

### DIFF
--- a/lib/hooks/use-scroll.ts
+++ b/lib/hooks/use-scroll.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 
+/**
+ * React hook to observe scroll postion.
+ * @param threshold {number} The y-axis position to observe.
+ * @returns {boolean} `True` when the user's vertical scroll position is greater than the `threshold`; otherwise, `False`.
+ */
 export default function useScroll(threshold: number) {
   const [scrolled, setScrolled] = useState(false);
 

--- a/lib/hooks/use-scroll.ts
+++ b/lib/hooks/use-scroll.ts
@@ -8,6 +8,8 @@ export default function useScroll(threshold: number) {
   }, [threshold]);
 
   useEffect(() => {
+    window && onScroll(); // Call on first render. This correctly updates the `scrolled` state to `True` if the user's scroll position is greater than the `threshold` during the initial load.
+
     window.addEventListener("scroll", onScroll);
     return () => window.removeEventListener("scroll", onScroll);
   }, [onScroll]);


### PR DESCRIPTION
**Description**

The React hook `useScroll` can incorrectly reflect the initial `scrolled` state. This happens on first render, when the user's starting y-position is greater than the `threshold`. The state reports `false` when it should say `true`.

Here, you can see we've started with a vertical scroll position beyond the threshold. As such, the `Navbar` should have a slightly opaque background; however, it's completely transparent.

<img width="1728" alt="Screenshot 2023-10-18 at 3 36 51 PM" src="https://github.com/steven-tey/precedent/assets/22305592/6d5e05c6-cb0f-4aba-a4c5-476c1c7aed75">


**Solution**

One way to fix this is by checking the user's initial y-position on first mount. We do that by invoking the `onScroll` handler initially when also registering it as a scroll event listener. That way, we don't rely on a scrolled event to correctly update the state. **Note**: it will always render as `false` on the server, but correct itself immediately when the client first renders the component.

Here, we see our solution implemented and `Navbar` has the background we'd expect.

<img width="1728" alt="Screenshot 2023-10-18 at 3 37 09 PM" src="https://github.com/steven-tey/precedent/assets/22305592/31b86ae0-8e71-41fb-ad27-b70e3d72b191">