### PR TITLE
Add missing closing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://precedent.dev">
-  <img alt="Precedent – Building blocks for your Next project" src="https://precedent.dev/opengraph-image">
+  <img alt="Precedent – Building blocks for your Next project" src="https://precedent.dev/opengraph-image" />
   <h1 align="center">Precedent</h1>
 </a>
 


### PR DESCRIPTION
Adding the closing tag solves the error when trying to view the  readme in the editor using extensions like: https://github.com/xyc/vscode-mdx-preview

Before:
![image](https://github.com/steven-tey/precedent/assets/23265867/fb54697e-ba9b-425d-998a-5b42260ea4c7)

After:
![image](https://github.com/steven-tey/precedent/assets/23265867/6beb2930-6175-4439-b98b-97f7db5e578a)
