### PR TITLE
fix: remove deprecated jsonProtocol at prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["jsonProtocol"]
 }
 
 datasource db {


### PR DESCRIPTION
In this pull request, I have removed the deprecated jsonProtocol from the Prisma schema. This change was necessary to keep the codebase up-to-date and avoid potential issues in the future.

### Changes:
* Removed jsonProtocol from the Prisma schema file.