### PR TITLE
DRY `format:write`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "dev": "prisma generate && next dev",
     "build": "prisma generate && prisma db push && next build",
-    "format:write": "prettier --write \"**/*.{css,js,json,jsx,ts,tsx}\"",
-    "format": "prettier \"**/*.{css,js,json,jsx,ts,tsx}\"",
+    "format:write": "npm run format -- --write",
+    "format": "prettier --cache \"**/*.{css,js,json,jsx,ts,tsx}\"",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
The expected result for `format:write` can be achieved by passing`--write` flag to the original `format` script